### PR TITLE
[-] Technical - Add a new line at the end of the generated `package.json` file when releasing a new version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## [Unreleased]
 ### Changed
 - Technical - Upgrade `eslint` devDependency.
+- Technical - Add a new line at the end of the generated `package.json` file when releasing a new version.
 
 ### Fixed
 - Readme - Rewrite it according to the new functions exposed.
-- Release Creation - Add a new line at the end of `package.json` to avoid yarn conflicts.
 
 ## RELEASE 2.0.0 - 2019-09-19
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - Readme - Rewrite it according to the new functions exposed.
+- Release Creation - Add a new line at the end of `package.json` to avoid yarn conflicts.
 
 ## RELEASE 2.0.0 - 2019-09-19
 ### Changed

--- a/services/release-creator.js
+++ b/services/release-creator.js
@@ -4,6 +4,7 @@ const simpleGit = require('simple-git')();
 const semver = require('semver');
 const { getLinesOfChangelog, getPackageJson } = require('../utils/project-file-utils');
 const { GitPullError } = require('../utils/errors');
+const { packageJsonFileContent } = require('../utils/project-file-utils');
 
 const BRANCH_MASTER = 'master';
 const BRANCH_DEVEL = 'devel';
@@ -89,7 +90,7 @@ function ReleaseCreator(argv, options = {}) {
       const packageJson = getPackageJson();
       version = semver.inc(packageJson.version, releaseType, prereleaseTag);
       packageJson.version = version;
-      newVersionFile = JSON.stringify(packageJson, null, 2);
+      newVersionFile = packageJsonFileContent(packageJson);
     }
 
     // CHANGELOG

--- a/test/services/release-creator.js
+++ b/test/services/release-creator.js
@@ -7,6 +7,7 @@ const {
   ChangelogMissingError,
   GitPullError,
 } = require('../../utils/errors');
+const { packageJsonFileContent } = require('../../utils/project-file-utils');
 let ReleaseCreator = require('../../services/release-creator');
 
 const { expect } = chai;
@@ -357,11 +358,11 @@ describe('Services > Release Creator', () => {
           });
 
           it('should update the package.json', () => {
-            expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+            expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
               name: 'lumber-cli',
               description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
               version: '2.3.10',
-            }, null, 2));
+            }));
           });
 
           it('should pull and commit changes', () => {
@@ -425,11 +426,11 @@ describe('Services > Release Creator', () => {
         });
 
         it('should update the package.json', () => {
-          expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+          expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
             name: 'lumber-cli',
             description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
             version: '2.4.0',
-          }, null, 2));
+          }));
         });
 
         it('should pull and commit changes', () => {
@@ -492,11 +493,11 @@ describe('Services > Release Creator', () => {
         });
 
         it('should update the package.json', () => {
-          expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+          expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
             name: 'lumber-cli',
             description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
             version: '3.0.0',
-          }, null, 2));
+          }));
         });
 
         it('should pull and commit changes', () => {
@@ -576,11 +577,11 @@ describe('Services > Release Creator', () => {
           });
 
           it('should update the package.json', () => {
-            expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+            expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
               name: 'lumber-cli',
               description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
               version: '2.3.9-beta.1',
-            }, null, 2));
+            }));
           });
 
           it('should pull and commit changes', () => {
@@ -640,11 +641,11 @@ describe('Services > Release Creator', () => {
           });
 
           it('should update the package.json', () => {
-            expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+            expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
               name: 'lumber-cli',
               description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
               version: '2.3.9-alpha.0',
-            }, null, 2));
+            }));
           });
 
           it('should pull and commit changes', () => {
@@ -706,11 +707,11 @@ describe('Services > Release Creator', () => {
           });
 
           it('should update the package.json', () => {
-            expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+            expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
               name: 'lumber-cli',
               description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
               version: '2.3.10-beta.0',
-            }, null, 2));
+            }));
           });
 
           it('should pull and commit changes', () => {
@@ -770,11 +771,11 @@ describe('Services > Release Creator', () => {
           });
 
           it('should update the package.json', () => {
-            expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+            expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
               name: 'lumber-cli',
               description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
               version: '2.3.10-alpha.0',
-            }, null, 2));
+            }));
           });
 
           it('should pull and commit changes', () => {
@@ -836,11 +837,11 @@ describe('Services > Release Creator', () => {
           });
 
           it('should update the package.json', () => {
-            expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+            expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
               name: 'lumber-cli',
               description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
               version: '2.4.0-beta.0',
-            }, null, 2));
+            }));
           });
 
           it('should pull and commit changes', () => {
@@ -900,11 +901,11 @@ describe('Services > Release Creator', () => {
           });
 
           it('should update the package.json', () => {
-            expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+            expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
               name: 'lumber-cli',
               description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
               version: '2.4.0-alpha.0',
-            }, null, 2));
+            }));
           });
 
           it('should pull and commit changes', () => {
@@ -966,11 +967,11 @@ describe('Services > Release Creator', () => {
           });
 
           it('should update the package.json', () => {
-            expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+            expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
               name: 'lumber-cli',
               description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
               version: '3.0.0-beta.0',
-            }, null, 2));
+            }));
           });
 
           it('should pull and commit changes', () => {
@@ -1030,11 +1031,11 @@ describe('Services > Release Creator', () => {
           });
 
           it('should update the package.json', () => {
-            expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+            expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
               name: 'lumber-cli',
               description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
               version: '3.0.0-alpha.0',
-            }, null, 2));
+            }));
           });
 
           it('should pull and commit changes', () => {
@@ -1104,11 +1105,11 @@ describe('Services > Release Creator', () => {
         });
 
         it('should update the package.json', () => {
-          expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+          expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
             name: 'lumber-cli',
             description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
             version: '2.3.10',
-          }, null, 2));
+          }));
         });
 
         it('should pull and commit changes', () => {
@@ -1167,11 +1168,11 @@ describe('Services > Release Creator', () => {
         });
 
         it('should update the package.json', () => {
-          expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+          expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
             name: 'lumber-cli',
             description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
             version: '2.4.0',
-          }, null, 2));
+          }));
         });
 
         it('should pull and commit changes', () => {
@@ -1230,11 +1231,11 @@ describe('Services > Release Creator', () => {
         });
 
         it('should update the package.json', () => {
-          expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+          expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
             name: 'lumber-cli',
             description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
             version: '3.0.0',
-          }, null, 2));
+          }));
         });
 
         it('should pull and commit changes', () => {
@@ -1312,11 +1313,11 @@ describe('Services > Release Creator', () => {
           });
 
           it('should update the package.json', () => {
-            expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+            expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
               name: 'lumber-cli',
               description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
               version: '2.3.9-beta.1',
-            }, null, 2));
+            }));
           });
 
           it('should pull and commit changes', () => {
@@ -1376,11 +1377,11 @@ describe('Services > Release Creator', () => {
           });
 
           it('should update the package.json', () => {
-            expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+            expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
               name: 'lumber-cli',
               description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
               version: '2.3.9-alpha.0',
-            }, null, 2));
+            }));
           });
 
           it('should pull and commit changes', () => {
@@ -1442,11 +1443,11 @@ describe('Services > Release Creator', () => {
           });
 
           it('should update the package.json', () => {
-            expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+            expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
               name: 'lumber-cli',
               description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
               version: '2.3.10-beta.0',
-            }, null, 2));
+            }));
           });
 
           it('should pull and commit changes', () => {
@@ -1506,11 +1507,11 @@ describe('Services > Release Creator', () => {
           });
 
           it('should update the package.json', () => {
-            expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+            expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
               name: 'lumber-cli',
               description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
               version: '2.3.10-alpha.0',
-            }, null, 2));
+            }));
           });
 
           it('should pull and commit changes', () => {
@@ -1572,11 +1573,11 @@ describe('Services > Release Creator', () => {
           });
 
           it('should update the package.json', () => {
-            expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+            expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
               name: 'lumber-cli',
               description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
               version: '2.4.0-beta.0',
-            }, null, 2));
+            }));
           });
 
           it('should pull and commit changes', () => {
@@ -1636,11 +1637,11 @@ describe('Services > Release Creator', () => {
           });
 
           it('should update the package.json', () => {
-            expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+            expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
               name: 'lumber-cli',
               description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
               version: '2.4.0-alpha.0',
-            }, null, 2));
+            }));
           });
 
           it('should pull and commit changes', () => {
@@ -1702,11 +1703,11 @@ describe('Services > Release Creator', () => {
           });
 
           it('should update the package.json', () => {
-            expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+            expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
               name: 'lumber-cli',
               description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
               version: '3.0.0-beta.0',
-            }, null, 2));
+            }));
           });
 
           it('should pull and commit changes', () => {
@@ -1766,11 +1767,11 @@ describe('Services > Release Creator', () => {
           });
 
           it('should update the package.json', () => {
-            expect(fs.readFileSync('package.json').toString()).equal(JSON.stringify({
+            expect(fs.readFileSync('package.json').toString()).equal(packageJsonFileContent({
               name: 'lumber-cli',
               description: 'Create your backend application in minutes. GraphQL API backend based on a database schema',
               version: '3.0.0-alpha.0',
-            }, null, 2));
+            }));
           });
 
           it('should pull and commit changes', () => {

--- a/test/utils/project-file-utils.js
+++ b/test/utils/project-file-utils.js
@@ -1,0 +1,13 @@
+const chai = require('chai');
+chai.use(require('chai-as-promised'));
+const { packageJsonFileContent } = require('../../utils/project-file-utils');
+
+const { expect } = chai;
+
+describe('Utils', () => {
+  describe('packageJsonFileContent', () => {
+    it('should convert JSON object to string including a new line', async () => {
+      expect(packageJsonFileContent({ version: '1'})).equal('{\n  "version": "1"\n}\n');
+    });
+  });
+});

--- a/test/utils/project-file-utils.js
+++ b/test/utils/project-file-utils.js
@@ -7,7 +7,7 @@ const { expect } = chai;
 describe('Utils', () => {
   describe('packageJsonFileContent', () => {
     it('should convert JSON object to string including a new line', async () => {
-      expect(packageJsonFileContent({ version: '1'})).equal('{\n  "version": "1"\n}\n');
+      expect(packageJsonFileContent({ version: '1' })).equal('{\n  "version": "1"\n}\n');
     });
   });
 });

--- a/utils/project-file-utils.js
+++ b/utils/project-file-utils.js
@@ -14,7 +14,12 @@ function getPackageJson() {
   return JSON.parse(packageContents);
 }
 
+function packageJsonFileContent(packageJson) {
+  return JSON.stringify(packageJson, null, 2).concat('\n');
+}
+
 module.exports = {
   getLinesOfChangelog,
   getPackageJson,
+  packageJsonFileContent,
 };


### PR DESCRIPTION
Every time a yarn operation is done that interact with `package.json` file, or a manual modification using VS code, it adds a new line. Github also prefers new lines at the end of a file. With this modification, a new line is added at the end of the `package.json` file after editing it.