### PR TITLE
fix(click up): fix click up task id detection (CU-60rxnt)

### DIFF
--- a/services/clickup-status-updater.js
+++ b/services/clickup-status-updater.js
@@ -36,7 +36,7 @@ function ClickUpStatusUpdater() {
   }
 
   function getClickUpTaskIdFromTitle(pullRequestTitle) {
-    const index = pullRequestTitle.indexOf('(#') + 2;
+    const index = pullRequestTitle.indexOf('(CU-') + 4;
 
     const clickUpTag = pullRequestTitle.substring(index);
     return clickUpTag.substring(0, clickUpTag.indexOf(')'));
@@ -118,7 +118,7 @@ function ClickUpStatusUpdater() {
   }
 
   function containsClikUpTagId(title) {
-    return /\(#\w{6,}\)/gm.test(title);
+    return /\(CU-\w{6,}\)/gm.test(title);
   }
 
   async function fetchTask(taskId, withSubTasks = false) {


### PR DESCRIPTION
Click Up task id has changed
Before they were looking like that: `#60rxnt`
Now they are like that: `CU-60rxnt`

So the script needed an update to work correctly

task linked and working for testing: https://app.clickup.com/t/60rxnt